### PR TITLE
feat: Implement remaining Phase 2 features and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,38 @@ To use the ResizableTable plugin, include the script in your HTML file and then 
     });
     ```
 
+## Configuration Options
+
+The `ResizableTable` constructor accepts an optional second argument, an `options` object, to customize its behavior:
+
+```javascript
+const options = {
+  resizeUpdateInterval: 0, // Default
+  deferDomWrites: false    // Default
+};
+const tableInstance = new ResizableTable('#myTable', options);
+```
+
+Below are the available options:
+
+### `resizeUpdateInterval`
+*   **Type:** `Number`
+*   **Default:** `0`
+*   **Description:** Specifies the minimum interval in milliseconds between column width updates during a resize drag operation. When set to `0` (default), updates are driven by `requestAnimationFrame` for maximum smoothness. A positive value (e.g., `50` or `100`) throttles updates, potentially improving performance on complex tables or slower devices at the cost of visual smoothness.
+*   **Example:**
+    ```javascript
+    new ResizableTable('#myTable', { resizeUpdateInterval: 100 });
+    ```
+
+### `deferDomWrites`
+*   **Type:** `Boolean`
+*   **Default:** `false`
+*   **Description:** **Experimental.** When set to `true`, DOM write operations (updating column style widths) during resize are deferred using `requestIdleCallback`, if available in the browser. This is intended to free up the main thread, but may introduce a perceptible lag between the drag action and the visual update. The final update upon drag completion is always synchronous. Use with caution.
+*   **Example:**
+    ```javascript
+    new ResizableTable('#myTable', { deferDomWrites: true });
+    ```
+
 ---
 
 **Note:** This project is currently under active development. Features and API are subject to change.
@@ -119,10 +151,10 @@ To use the ResizableTable plugin, include the script in your HTML file and then 
     - [x] Initialize column widths from computed styles or explicitly set `cell.style.width`.
 - [~] 3. Rowspan and Colspan Handling
     - [x] Detect and log `rowspan`/`colspan` on header cells.
-    - [ ] Advanced handling logic (Not Implemented)
-- [ ] 4. Performance Optimization
-    - [ ] Optional throttling via user-defined `updateInterval` (Not Implemented)
-    - [ ] Defer DOM writes via `requestIdleCallback` (Not Implemented)
+    - [x] Advanced handling logic for colspan. Rowspan detection continues to log warnings.
+- [x] 4. Performance Optimization
+    - [x] Optional throttling via user-defined `updateInterval`.
+    - [x] Defer DOM writes via `requestIdleCallback` (experimental).
 
 ### PHASE 3: Collapsible Columns
 - [~] 1. Collapse Toggle Setup (`_createCollapseToggles()`, `_onCollapseToggle`)

--- a/tests/resizable-table.test.html
+++ b/tests/resizable-table.test.html
@@ -1,0 +1,421 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>ResizableTable Tests</title>
+    <style>
+        /* Basic styling for visibility */
+        table {
+            border-collapse: collapse;
+            margin-bottom: 20px;
+        }
+        th, td {
+            border: 1px solid black;
+            padding: 8px;
+            min-width: 50px; /* Ensure columns have some initial width */
+        }
+        .rt-resize-handle {
+            /* Ensure handles are visible for debugging, though tests won't rely on visual interaction */
+            background-color: rgba(0, 0, 255, 0.2);
+        }
+        #test-container {
+            margin-top: 20px;
+        }
+    </style>
+</head>
+<body>
+
+<h1>ResizableTable Unit Tests</h1>
+<div id="test-summary">
+    <p>Tests Run: <span id="tests-run">0</span></p>
+    <p>Tests Passed: <span id="tests-passed">0</span></p>
+    <p>Tests Failed: <span id="tests-failed">0</span></p>
+</div>
+<div id="test-output">
+    <!-- Test results will be logged to the console -->
+</div>
+<div id="test-container"></div>
+
+<script src="../src/ResizableTable.js"></script>
+<script>
+    let testsRun = 0;
+    let testsPassed = 0;
+    const originalDateNow = Date.now;
+    const originalRequestAnimationFrame = window.requestAnimationFrame;
+    const originalRequestIdleCallback = window.requestIdleCallback;
+    let rAFCallback = null;
+    let rICCallback = null;
+    let mockDateNowValue = originalDateNow();
+
+    // --- Test Infrastructure ---
+    function assert(condition, message) {
+        testsRun++;
+        if (condition) {
+            testsPassed++;
+            console.log(`%cPASS: ${message}`, 'color: green;');
+        } else {
+            console.error(`FAIL: ${message}`);
+        }
+        updateSummary();
+    }
+
+    function updateSummary() {
+        document.getElementById('tests-run').textContent = testsRun;
+        document.getElementById('tests-passed').textContent = testsPassed;
+        document.getElementById('tests-failed').textContent = testsRun - testsPassed;
+    }
+
+    function resetTestEnv() {
+        document.getElementById('test-container').innerHTML = '';
+        // Restore original functions
+        Date.now = originalDateNow;
+        window.requestAnimationFrame = originalRequestAnimationFrame;
+        window.requestIdleCallback = originalRequestIdleCallback;
+        rAFCallback = null;
+        rICCallback = null;
+        mockDateNowValue = originalDateNow();
+        // Reset spies or mocks on tableInstance methods
+        if (currentTableInstance && currentTableInstance._updateColumnWidth && currentTableInstance._updateColumnWidth.isSpy) {
+            currentTableInstance._updateColumnWidth = currentTableInstance._updateColumnWidth.originalFn;
+        }
+    }
+
+    function createTableHTML(id, headerHTML) {
+        return `<table id="${id}"><thead>${headerHTML}</thead><tbody><tr><td>Data</td><td>Data</td><td>Data</td></tr></tbody></table>`;
+    }
+
+    function simulateMouseEvent(type, element, clientX) {
+        const event = new MouseEvent(type, {
+            bubbles: true,
+            cancelable: true,
+            view: window,
+            clientX: clientX,
+            // Make sure buttons property is set for mousedown
+            buttons: type === 'mousedown' ? 1 : 0,
+        });
+        element.dispatchEvent(event);
+    }
+
+    function approximatelyEqual(val1, val2, epsilon = 2) { // Epsilon of 2px for width comparisons
+        return Math.abs(val1 - val2) < epsilon;
+    }
+
+    function spyOn(object, methodName) {
+        const originalFn = object[methodName];
+        if (typeof originalFn !== 'function') {
+            throw new Error(`Cannot spy on non-function ${methodName}`);
+        }
+        let callCount = 0;
+        const spy = (...args) => {
+            callCount++;
+            return originalFn.apply(object, args);
+        };
+        spy.callCount = () => callCount;
+        spy.originalFn = originalFn;
+        spy.isSpy = true;
+        object[methodName] = spy;
+        return spy;
+    }
+
+    let currentTableInstance = null; // To hold the instance for spy reset or access
+
+    // --- Test Suites ---
+    async function runTests() {
+        console.log("Starting tests...");
+
+        // I. Colspan Handling
+        await testColspanInitialization();
+        await testColspanResizing();
+
+        // II. Optional Throttling
+        await testThrottlingActive();
+        await testThrottlingInactive();
+
+        // III. Conditional requestIdleCallback
+        await testDeferDomWritesTrue();
+        await testDeferDomWritesFalse();
+        await testDeferDomWritesTrueFinalUpdateSync();
+
+        console.log("--- Test Summary ---");
+        console.log(`Total Tests: ${testsRun}, Passed: ${testsPassed}, Failed: ${testsRun - testsPassed}`);
+        updateSummary(); // Final update
+    }
+
+    // Test Case 1.1
+    async function testColspanInitialization() {
+        resetTestEnv();
+        console.log("--- Test 1.1: Colspan Initialization ---");
+        const tableHTML = createTableHTML('table1', '<tr><th colspan="2">A</th><th>B</th></tr>');
+        document.getElementById('test-container').innerHTML = tableHTML;
+        const tableEl = document.getElementById('table1');
+        currentTableInstance = new ResizableTable(tableEl);
+
+        assert(currentTableInstance.columnCount === 3, "Correct columnCount (3) with colspan=2");
+        assert(currentTableInstance.columnWidths.length === 3, "columnWidths array length is 3");
+
+        const th0 = currentTableInstance.headerRow.cells[0];
+        const th0Width = parseFloat(th0.style.width);
+        const sumOfSpannedWidths = currentTableInstance.columnWidths[0] + currentTableInstance.columnWidths[1];
+        assert(approximatelyEqual(th0Width, sumOfSpannedWidths),
+            `TH width (${th0Width.toFixed(2)}) should be approx sum of its columnWidths (${currentTableInstance.columnWidths[0].toFixed(2)} + ${currentTableInstance.columnWidths[1].toFixed(2)} = ${sumOfSpannedWidths.toFixed(2)})`);
+    }
+
+    // Test Case 1.2
+    async function testColspanResizing() {
+        resetTestEnv();
+        console.log("--- Test 1.2: Resizing last column in a colspan ---");
+        const tableHTML = createTableHTML('table2', '<tr><th id="thA" colspan="2">A</th><th id="thB">B</th></tr>');
+        document.getElementById('test-container').innerHTML = tableHTML;
+        const tableEl = document.getElementById('table2');
+        currentTableInstance = new ResizableTable(tableEl);
+
+        const thA = document.getElementById('thA');
+        const initialWidthCol0 = currentTableInstance.columnWidths[0];
+        const initialWidthCol1 = currentTableInstance.columnWidths[1];
+        const initialWidthCol2 = currentTableInstance.columnWidths[2];
+        const initialThAWidth = parseFloat(thA.style.width);
+
+        assert(initialWidthCol0 > 0 && initialWidthCol1 > 0, "Initial widths for spanned columns are positive");
+
+        const resizeHandle = thA.querySelector('.rt-resize-handle');
+        assert(resizeHandle !== null, "Resize handle exists on colspan TH");
+        assert(parseInt(resizeHandle.dataset.columnIndex) === 1, "Handle on colspan TH targets the last actual column (index 1) in its span");
+
+        const startX = 100;
+        const deltaX = 30; // Increase width by 30px
+
+        simulateMouseEvent('mousedown', resizeHandle, startX);
+        // Need to add the listeners to document for mousemove/mouseup as ResizableTable does
+        // For this test, we'll assume _onDragStart correctly sets up this.currentColumnIndex etc.
+        // We need to manually set isResizing for _updateColumnWidth if not going through full event flow
+        currentTableInstance.isResizing = true;
+        currentTableInstance.startX = startX;
+        currentTableInstance.currentColumnIndex = parseInt(resizeHandle.dataset.columnIndex); // Should be 1
+        currentTableInstance.currentHeaderCellIndex = 0; // Header cell 0
+        currentTableInstance.startWidth = currentTableInstance.columnWidths[currentTableInstance.currentColumnIndex];
+
+
+        currentTableInstance.lastMouseX = startX + deltaX;
+        currentTableInstance._updateColumnWidth(true); // Force sync for test simplicity here
+
+        simulateMouseEvent('mouseup', document, startX + deltaX); // target is document for mouseup
+        currentTableInstance.isResizing = false;
+
+
+        const finalWidthCol0 = currentTableInstance.columnWidths[0];
+        const finalWidthCol1 = currentTableInstance.columnWidths[1];
+        const finalWidthCol2 = currentTableInstance.columnWidths[2];
+        const finalThAWidth = parseFloat(thA.style.width);
+
+        console.log(`Initial widths: col0=${initialWidthCol0.toFixed(1)}, col1=${initialWidthCol1.toFixed(1)}, thA=${initialThAWidth.toFixed(1)}`);
+        console.log(`Final widths:   col0=${finalWidthCol0.toFixed(1)}, col1=${finalWidthCol1.toFixed(1)}, thA=${finalThAWidth.toFixed(1)}`);
+
+        assert(approximatelyEqual(finalWidthCol0, initialWidthCol0), `Width of first actual column (idx 0) should not change significantly. Initial: ${initialWidthCol0.toFixed(1)}, Final: ${finalWidthCol0.toFixed(1)}`);
+        assert(!approximatelyEqual(finalWidthCol1, initialWidthCol1) && finalWidthCol1 > initialWidthCol1, `Width of second actual column (idx 1) should change. Initial: ${initialWidthCol1.toFixed(1)}, Final: ${finalWidthCol1.toFixed(1)}`);
+        assert(approximatelyEqual(finalWidthCol1, initialWidthCol1 + deltaX, 5), `Width of second actual column (idx 1) should increase by approx deltaX. Expected: ${initialWidthCol1+deltaX}, Got: ${finalWidthCol1}`);
+
+        assert(approximatelyEqual(finalWidthCol2, initialWidthCol2), "Width of third actual column (idx 2) should not change");
+
+        const expectedThAWidth = finalWidthCol0 + finalWidthCol1;
+        assert(approximatelyEqual(finalThAWidth, expectedThAWidth),
+            `TH_A style.width (${finalThAWidth.toFixed(1)}) should be sum of its new columnWidths (${finalWidthCol0.toFixed(1)} + ${finalWidthCol1.toFixed(1)} = ${expectedThAWidth.toFixed(1)})`);
+    }
+
+    // Test Case 2.1
+    async function testThrottlingActive() {
+        resetTestEnv();
+        console.log("--- Test 2.1: Throttling Active ---");
+        const tableHTML = createTableHTML('table3', '<tr><th>C1</th><th>C2</th></tr>');
+        document.getElementById('test-container').innerHTML = tableHTML;
+        const tableEl = document.getElementById('table3');
+
+        let rAFCallCount = 0;
+        window.requestAnimationFrame = (cb) => { rAFCallback = cb; rAFCallCount++; return 0; }; // Mock rAF
+        Date.now = () => mockDateNowValue; // Mock Date.now
+
+        currentTableInstance = new ResizableTable(tableEl, { resizeUpdateInterval: 100 });
+        const spyUpdate = spyOn(currentTableInstance, '_updateColumnWidth');
+
+        const handle = currentTableInstance.resizeHandles[0];
+        simulateMouseEvent('mousedown', handle, 100);
+
+        // Move 1 (time 0) - should call
+        mockDateNowValue += 10; // time = 10
+        simulateMouseEvent('mousemove', document, 105);
+        if(rAFCallback) rAFCallback();
+        assert(spyUpdate.callCount() === 1, "Move 1: _updateColumnWidth called (time 10)");
+        let lastCallTime = mockDateNowValue;
+
+
+        // Move 2 (time 20) - should be throttled
+        mockDateNowValue += 10; // time = 20
+        simulateMouseEvent('mousemove', document, 110);
+        if(rAFCallback && spyUpdate.callCount() === 1) rAFCallback(); // rAF might be scheduled but _throttledUpdate condition fails
+        assert(spyUpdate.callCount() === 1, "Move 2: _updateColumnWidth NOT called (time 20, throttled)");
+
+        // Move 3 (time 110) - interval passed from last call (10)
+        mockDateNowValue = lastCallTime + 100; // time = 10 + 100 = 110
+        simulateMouseEvent('mousemove', document, 115);
+        if(rAFCallback) rAFCallback();
+        assert(spyUpdate.callCount() === 2, `Move 3: _updateColumnWidth called again (time ${mockDateNowValue})`);
+
+        simulateMouseEvent('mouseup', document, 115);
+        assert(spyUpdate.callCount() === 3, "Mouseup: _updateColumnWidth called for final update");
+    }
+
+    // Test Case 2.2
+    async function testThrottlingInactive() {
+        resetTestEnv();
+        console.log("--- Test 2.2: Throttling Inactive (Default) ---");
+        const tableHTML = createTableHTML('table4', '<tr><th>C1</th><th>C2</th></tr>');
+        document.getElementById('test-container').innerHTML = tableHTML;
+        const tableEl = document.getElementById('table4');
+
+        window.requestAnimationFrame = (cb) => { rAFCallback = cb; return 0; }; // Mock rAF
+
+        currentTableInstance = new ResizableTable(tableEl); // No interval
+        const spyUpdate = spyOn(currentTableInstance, '_updateColumnWidth');
+
+        const handle = currentTableInstance.resizeHandles[0];
+        simulateMouseEvent('mousedown', handle, 100);
+
+        simulateMouseEvent('mousemove', document, 105); if(rAFCallback) rAFCallback();
+        simulateMouseEvent('mousemove', document, 110); if(rAFCallback) rAFCallback();
+        simulateMouseEvent('mousemove', document, 115); if(rAFCallback) rAFCallback();
+
+        assert(spyUpdate.callCount() === 3, "3 Moves: _updateColumnWidth called 3 times (via rAF)");
+
+        simulateMouseEvent('mouseup', document, 115);
+        assert(spyUpdate.callCount() === 4, "Mouseup: _updateColumnWidth called for final update");
+    }
+
+    // Test Case 3.1
+    async function testDeferDomWritesTrue() {
+        resetTestEnv();
+        console.log("--- Test 3.1: deferDomWrites true ---");
+        const tableHTML = createTableHTML('table5', '<tr><th id="thC1">C1</th><th>C2</th></tr>');
+        document.getElementById('test-container').innerHTML = tableHTML;
+        const tableEl = document.getElementById('table5');
+        const thC1 = document.getElementById('thC1');
+
+        let rICWasCalled = false;
+        let rICScheduledFn = null;
+        window.requestIdleCallback = (cb) => { rICScheduledFn = cb; rICWasCalled = true; return 0; };
+        window.requestAnimationFrame = (cb) => { cb(); }; // Execute rAF callback immediately
+
+        currentTableInstance = new ResizableTable(tableEl, { deferDomWrites: true });
+        const originalWidth = thC1.style.width;
+
+        const handle = currentTableInstance.resizeHandles[0];
+        simulateMouseEvent('mousedown', handle, 100);
+        simulateMouseEvent('mousemove', document, 120); // This will call _updateColumnWidth via rAF -> _throttledUpdate (or direct)
+
+        assert(rICWasCalled, "requestIdleCallback was called");
+        const widthAfterMoveBeforeRIC = thC1.style.width;
+        // Note: initial width might be like "XXpx", if it wasn't set before by JS.
+        // If ResizableTable sets it during init, this comparison is more robust.
+        // Let's assume ResizableTable sets an initial pixel width.
+        const initialPixelWidth = currentTableInstance.columnWidths[0] + 'px'; // approx
+        console.log(`Initial TH width: ${initialPixelWidth}, Width after move (before rIC exec): ${widthAfterMoveBeforeRIC}`);
+
+        // This assertion depends on the initial width being different from the potential new width.
+        // The key is that the *new* width from resizing hasn't been applied yet.
+        // If initial style.width was empty, this check is tricky.
+        // Let's check that it's NOT the new width.
+        const currentCalculatedNewWidth = (currentTableInstance.columnWidths[0]) + 'px'; // This is what it would be after the update.
+
+        // This assertion can be tricky due to how initial widths are set vs. how they are after first calculation.
+        // A more robust check might be to see if the width *changes* after rIC.
+        // For now, let's assume it's not yet the final width it will be.
+        // assert(thC1.style.width !== currentCalculatedNewWidth, `th.style.width (${thC1.style.width}) not updated synchronously. Expected to not be ${currentCalculatedNewWidth}`);
+        // Let's check if it's still the original width that was set during init.
+        // This is only valid if the column was not already at the new target size.
+        // This test is simplified: we check rIC was called. The actual width check is complex.
+        // A better way: store width, execute rIC, check it changed.
+        const widthBeforeRICExecute = thC1.style.width;
+
+        if (rICScheduledFn) {
+            rICScheduledFn(); // Execute the rIC callback
+        }
+        assert(thC1.style.width !== widthBeforeRICExecute, `th.style.width (${thC1.style.width}) IS updated after rIC callback. Was: ${widthBeforeRICExecute}`);
+
+        simulateMouseEvent('mouseup', document, 120); // Cleanup
+    }
+
+    // Test Case 3.2
+    async function testDeferDomWritesFalse() {
+        resetTestEnv();
+        console.log("--- Test 3.2: deferDomWrites false ---");
+        const tableHTML = createTableHTML('table6', '<tr><th id="thD1">D1</th><th>D2</th></tr>');
+        document.getElementById('test-container').innerHTML = tableHTML;
+        const tableEl = document.getElementById('table6');
+        const thD1 = document.getElementById('thD1');
+
+        let rICWasCalled = false;
+        window.requestIdleCallback = (cb) => { rICWasCalled = true; /* ... */ };
+        window.requestAnimationFrame = (cb) => { cb(); }; // Execute rAF callback immediately
+
+        currentTableInstance = new ResizableTable(tableEl, { deferDomWrites: false });
+        const originalWidth = thD1.style.width; // Width set by ResizableTable init
+
+        const handle = currentTableInstance.resizeHandles[0];
+        simulateMouseEvent('mousedown', handle, 100);
+        simulateMouseEvent('mousemove', document, 120);
+
+        assert(!rICWasCalled, "requestIdleCallback was NOT called");
+        assert(thD1.style.width !== originalWidth, `th.style.width (${thD1.style.width}) WAS updated synchronously (was ${originalWidth})`);
+
+        simulateMouseEvent('mouseup', document, 120); // Cleanup
+    }
+
+    // Test Case 3.3
+    async function testDeferDomWritesTrueFinalUpdateSync() {
+        resetTestEnv();
+        console.log("--- Test 3.3: Synchronous final update with deferDomWrites true ---");
+        const tableHTML = createTableHTML('table7', '<tr><th id="thE1">E1</th><th>E2</th></tr>');
+        document.getElementById('test-container').innerHTML = tableHTML;
+        const tableEl = document.getElementById('table7');
+        const thE1 = document.getElementById('thE1');
+
+        let rICWasCalledOnMove = false;
+        let rICWasCalledOnUp = false;
+        let rICScheduledFn = null;
+
+        window.requestAnimationFrame = (cb) => { cb(); }; // Execute rAF callback immediately
+
+        currentTableInstance = new ResizableTable(tableEl, { deferDomWrites: true });
+        const originalWidth = thE1.style.width;
+
+        const handle = currentTableInstance.resizeHandles[0];
+        simulateMouseEvent('mousedown', handle, 100);
+
+        // Rig rIC for the mousemove call
+        window.requestIdleCallback = (cb) => {
+            rICScheduledFn = cb;
+            rICWasCalledOnMove = true;
+        };
+        simulateMouseEvent('mousemove', document, 120);
+        // Execute the rIC from mousemove to get it out of the way
+        if (rICScheduledFn) rICScheduledFn();
+        rICScheduledFn = null;
+
+        // Rig rIC for the mouseup call (it shouldn't be called)
+        window.requestIdleCallback = (cb) => {
+            rICScheduledFn = cb;
+            rICWasCalledOnUp = true;
+        };
+        const widthBeforeMouseUp = thE1.style.width;
+        simulateMouseEvent('mouseup', document, 125); // Different X to ensure width change
+
+        assert(rICWasCalledOnMove, "requestIdleCallback was called for mousemove");
+        assert(!rICWasCalledOnUp, "requestIdleCallback was NOT called for final update on mouseup");
+        assert(thE1.style.width !== widthBeforeMouseUp, `th.style.width (${thE1.style.width}) WAS updated synchronously on mouseup (was ${widthBeforeMouseUp})`);
+    }
+
+
+    // --- Run All Tests ---
+    document.addEventListener('DOMContentLoaded', runTests);
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
This commit completes the planned features for Phase 2 of the ResizableTable plugin:

1.  **Advanced Colspan Handling:**
    *   Implemented logic to correctly resize columns that are part of a `colspan`.
    *   The resize handle on a `<th>` with `colspan` now targets the last actual column in its span for resizing.
    *   The internal `columnWidths` array accurately tracks individual column widths.
    *   `rowspan` handling remains as detection and logging of warnings.

2.  **Performance Optimizations (Optional):**
    *   Added `resizeUpdateInterval` option: Allows throttling of resize updates via `requestAnimationFrame` to a specified millisecond interval, potentially improving performance on complex tables. Defaults to 0 (unthrottled).
    *   Added `deferDomWrites` option (experimental): Allows deferring DOM write operations (column width styles) during resize using `requestIdleCallback`. This is experimental and may introduce visual lag. The final update on drag completion is always synchronous. Defaults to `false`.

3.  **Unit Tests:**
    *   Added a new test suite (`tests/resizable-table.test.html`).
    *   Includes tests for `colspan` initialization and resizing logic.
    *   Includes tests for `resizeUpdateInterval` (throttled and unthrottled scenarios).
    *   Includes tests for `deferDomWrites` (synchronous, deferred, and final update behavior).

4.  **Documentation:**
    *   Updated `README.md` to mark Phase 2 features as complete.
    *   Added a "Configuration Options" section to `README.md` detailing the new `resizeUpdateInterval` and `deferDomWrites` options.